### PR TITLE
Install NodeJs (latest) for the Raspberry Pi

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,14 @@ Install Nodejs
 
 https://nodejs.org/en/download/package-manager/
 
+
+Install latest version of NodeJs for the Raspberry Pi:
+
+```sh
+
+sudo wget -O - https://raw.githubusercontent.com/audstanley/NodeJs-Raspberry-Pi/master/Install-Node.sh | bash
+```
+
 Install dependencies with
 
 ```npm install``` 


### PR DESCRIPTION
A simple, single line install of the latest version of NodeJs on the Raspberry Pi (as of 8/26/2017 this is version 8.4.0).  This, of course, includes the ability to use ES6 features/syntax.  I'm not sure if this has a negative effect on current Node package dependencies that are for the Titan Rover, but would be willing to test this in the near future. 